### PR TITLE
fix(auth): validate login request and tenant config to prevent crashes

### DIFF
--- a/packages/auth-api/functions/auth.ts
+++ b/packages/auth-api/functions/auth.ts
@@ -11,17 +11,58 @@ const cognito = new CognitoIdentityProviderClient();
 
 export const loginHandler: APIGatewayProxyHandlerV2 = async (event) => {
   try {
-    const { email, password } = JSON.parse(event.body);
+    if (!event.body || typeof event.body !== "string") {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ message: "Request body is required" }),
+      };
+    }
+
+    const body = JSON.parse(event.body);
+    const email = body?.email;
+    const password = body?.password;
+
+    if (!email || !password) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ message: "Email and password are required" }),
+      };
+    }
+
+    const mainTable = process.env.MAIN_TABLE;
+    if (!mainTable) {
+      console.error("Login: MAIN_TABLE is not set");
+      return {
+        statusCode: 503,
+        body: JSON.stringify({ message: "Server configuration error" }),
+      };
+    }
 
     const result = await db.send(new GetItemCommand({
-        TableName: process.env.MAIN_TABLE,
+        TableName: mainTable,
         Key: marshall({
           PK: 'TENANT#hrk',
           SK: 'SETTINGS'
         })
       }));
-      
-      const { userPoolId, clientId } = unmarshall(result.Item!).settings.userPool;
+
+    const item = result.Item;
+    if (!item) {
+      console.error("Login: TENANT#hrk SETTINGS not found in database");
+      return {
+        statusCode: 503,
+        body: JSON.stringify({ message: "Server configuration error" }),
+      };
+    }
+
+    const { userPoolId, clientId } = unmarshall(item).settings?.userPool ?? {};
+    if (!userPoolId || !clientId) {
+      console.error("Login: userPoolId/clientId missing in SETTINGS");
+      return {
+        statusCode: 503,
+        body: JSON.stringify({ message: "Server configuration error" }),
+      };
+    }
 
       const command = new AdminInitiateAuthCommand({
         AuthFlow: "ADMIN_NO_SRP_AUTH",


### PR DESCRIPTION
- Validate event.body before JSON.parse; return 400 if missing/invalid
- Require email and password in body; return 400 if missing
- Check MAIN_TABLE env; return 503 if unset
- Check DynamoDB result.Item (TENANT#hrk SETTINGS); return 503 if missing
- Validate userPoolId/clientId from settings; return 503 if missing