### PR TITLE
docs: replace template README with project-specific documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,155 @@
-# React + TypeScript + Vite
+# Hårdrockskören – Applikation
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+**Medlems- och administrationsapp för Hårdrockskören.** Webbapplikation för hantering av körmedlemmar, grupper, evenemang, närvaro och övningsmaterial, med separata gränssnitt för medlemmar och administratörer.
 
-Currently, two official plugins are available:
+---
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Översikt
 
-## Expanding the ESLint configuration
+Hrk-app är en fullständig, serverlös webbapplikation byggd som en **monorepo** med delad kod, tydlig ansvarsfördelning mellan tjänster och automatiserad deployment mot AWS. Backend består av flera API:er (auth, admin, event, material) som körs på AWS Lambda bakom API Gateway, med DynamoDB och S3 som persistering. Frontend är en React-app (Vite, TypeScript) som anropar dessa API:er och hanterar inloggning via AWS Cognito.
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+---
 
-```js
-export default tseslint.config({
-  extends: [
-    // Remove ...tseslint.configs.recommended and replace with this
-    ...tseslint.configs.recommendedTypeChecked,
-    // Alternatively, use this for stricter rules
-    ...tseslint.configs.strictTypeChecked,
-    // Optionally, add this for stylistic rules
-    ...tseslint.configs.stylisticTypeChecked,
-  ],
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+## Arkitektur
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                              Frontend (React + Vite)                     │
+│                    SPA, Cognito JWT, VITE_* env för API-URL:er            │
+└───────────────────────────────────┬─────────────────────────────────────┘
+                                    │ HTTPS
+        ┌───────────────────────────┼───────────────────────────┐
+        ▼                           ▼                           ▼
+┌───────────────┐  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐
+│   auth-api    │  │  admin-api     │  │  event-api     │  │ material-api   │
+│   (Lambda)    │  │  (Lambda)      │  │  (Lambda)      │  │  (Lambda)      │
+│ Login, reset  │  │ Grupper,       │  │ Evenemang,     │  │ Material,      │
+│               │  │ inbjudan,      │  │ list/filter    │  │ presigned S3   │
+│               │  │ användare,     │  │                │  │                │
+│               │  │ närvaro        │  │                │  │                │
+└───────┬───────┘  └───────┬───────┘  └───────┬───────┘  └───────┬───────┘
+        │                  │                  │                  │
+        └──────────────────┼──────────────────┼──────────────────┘
+                            ▼                  ▼
+        ┌───────────────────────────────────────────────────────────────┐
+        │  infra-service (en gång per miljö)                             │
+        │  DynamoDB (HrkMainTable + GSI, Invite, Attendance, Reset)       │
+        │  S3 (media, frontend), Cognito User Pool                        │
+        └───────────────────────────────────────────────────────────────┘
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+- **Single-table design:** Huvuddata i DynamoDB med PK/SK och GSI för olika access patterns.
+- **IAM per function:** Varje Lambda har minimal behörighet via `serverless-iam-roles-per-function`.
+- **Authorizer:** JWT-validering (Cognito) med cachelagring; admin/event/material använder samma authorizer där det passar.
+- **Filuppladdning:** Presigned S3-URL:er – filer laddas inte genom Lambda.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+---
 
-export default tseslint.config({
-  plugins: {
-    // Add the react-x and react-dom plugins
-    'react-x': reactX,
-    'react-dom': reactDom,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended typescript rules
-    ...reactX.configs['recommended-typescript'].rules,
-    ...reactDom.configs.recommended.rules,
-  },
-})
+## Teknisk stack
+
+| Lager        | Teknik                                                                  |
+| ------------ | ----------------------------------------------------------------------- |
+| **Frontend** | React 19, TypeScript, Vite 6, React Router, Tailwind/Sass, Lucide React |
+| **Backend**  | Node.js 18/20, AWS Lambda, API Gateway HTTP API, Serverless Framework 4 |
+| **Data**     | DynamoDB (PAY_PER_REQUEST), S3 (media + frontend-hosting)               |
+| **Auth**     | AWS Cognito (User Pool), JWT i Authorization-header                     |
+| **Infra**    | Serverless Compose (infra-service → auth, admin, event, material)       |
+
+---
+
+## Monorepo-struktur
+
 ```
+hrk-app/
+├── package.json              # Workspaces: packages/*
+├── packages/
+│   ├── frontend/             # React SPA (Vite)
+│   ├── core/                 # Delad kod: typer, auth-hjälp, http, permissions
+│   ├── infra-service/        # DynamoDB-tabeller, S3, Cognito (deployas först)
+│   ├── auth-api/             # Login, lösenordsåterställning
+│   ├── admin-api/            # Grupper, inbjudan, användare, närvaro
+│   ├── event-api/            # Evenemang
+│   ├── material-api/         # Övningsmaterial, globalt material, presigned upload
+│   └── serverless-compose.yml # Deploy-ordning för backend
+└── docs/                     # Dokumentation (arbetsflöden, analys, prioritering)
+```
+
+---
+
+## Förutsättningar
+
+- **Node.js** 18+ (rekommenderat 20 för parity med Lambda)
+- **AWS CLI** konfigurerat med rätt konto och behörighet att skapa Lambda, API Gateway, DynamoDB, S3, Cognito
+- **env-filer** per tjänst och stage (t.ex. `env.dev.yaml`, `env.prod.yaml`) – finns inte i Git; måste sättas upp manuellt eller från säker källa
+
+---
+
+## Kom igång
+
+### 1. Klona och installera
+
+```bash
+git clone <repo-url>
+cd hrk-app
+npm install
+```
+
+### 2. Backend (dev)
+
+Deploya infrastruktur och alla API:er till en dev-stage:
+
+```bash
+cd packages
+npx serverless deploy --stage dev
+```
+
+Anteckna de utskrivna HTTP API-URL:erna för varje tjänst (auth, admin, event, material).
+
+### 3. Konfigurera frontend
+
+I `packages/frontend` skapa `.env` med dev-API-URL:er:
+
+```env
+VITE_AUTH_API_URL=https://<auth-api-dev-url>
+VITE_ADMIN_API_URL=https://<admin-api-dev-url>
+VITE_EVENT_API_URL=https://<event-api-dev-url>
+VITE_MATERIAL_API_URL=https://<material-api-dev-url>
+VITE_S3_BUCKET_URL=https://<media-bucket-url>
+```
+
+### 4. Starta frontend lokalt
+
+```bash
+cd packages/frontend
+npm run dev
+```
+
+Öppna `http://localhost:5173` och logga in med en användare från dev-Cognito User Pool.
+
+### 5. Bygg och deploy till produktion
+
+- **Frontend:** `npm run build` i `packages/frontend`, sedan uppladdning till S3 (eller CI/CD).
+- **Backend:** `npx serverless deploy --stage prod` i `packages` (med korrekt `env.prod.yaml` per tjänst).
+
+Detaljerade steg finns i [docs/ARBETSFLODEN.md](docs/ARBETSFLODEN.md).
+
+---
+
+## Skript (root)
+
+- `npm run build` – generisk (använd workspace-specifika kommandon, t.ex. `npm run build -w frontend`).
+
+I varje `packages/<pkg>`:
+
+- **frontend:** `dev`, `build`, `preview`, `lint`
+- **admin-api / auth-api / event-api / material-api:** deploy via `serverless` i `packages` med `serverless-compose`
+
+---
+
+## Licens
+
+ISC.
+
+---
+
+_Hårdrockskören – hrk-app monorepo._


### PR DESCRIPTION
- Add overview of Hårdrockskören app (members, groups, events, material, attendance)
- Add ASCII architecture diagram (frontend, auth/admin/event/material APIs, infra)
- Document tech stack, monorepo layout, prerequisites
- Add getting started: install, deploy backend, frontend .env, dev server
- Link to docs (ARBETSFLODEN, BACKEND-ANALYS, BACKEND-PRIORITERING)