### PR TITLE
fix(material-api): use Query instead of Scan for Sjungupp practice ma…

### DIFF
--- a/packages/material-api/functions/listByWeek.ts
+++ b/packages/material-api/functions/listByWeek.ts
@@ -1,6 +1,6 @@
 // functions/practice/listByWeek.ts
 
-import { DynamoDBClient, ScanCommand } from "@aws-sdk/client-dynamodb";
+import { DynamoDBClient, QueryCommand } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
 import { APIGatewayProxyResultV2 } from "aws-lambda";
 import { sendResponse, sendError } from "../../core/utils/http";
@@ -8,6 +8,8 @@ import middy from "@middy/core";
 
 const dbClient = new DynamoDBClient({ region: process.env.AWS_REGION });
 const MAIN_TABLE = process.env.MAIN_TABLE;
+
+const PK_SJUNGUPP = "SJUNGUPP#MATERIALS";
 
 // Typ för ett enskilt material-objekt efter att det har hämtats och avkodats
 interface Material {
@@ -31,17 +33,27 @@ export const handler = middy().handler(
     }
 
     try {
-      // STEG 1: Hämta allt Sjungupp-material från DynamoDB
-      const scanCommand = new ScanCommand({
-        TableName: MAIN_TABLE,
-        FilterExpression: "PK = :pk",
-        ExpressionAttributeValues: {
-          ":pk": { S: "SJUNGUPP#MATERIALS" },
-        },
-      });
+      // STEG 1: Hämta allt Sjungupp-material via Query (samma partition) med paginering
+      const allItems: Material[] = [];
+      let lastEvaluatedKey: Record<string, unknown> | undefined;
 
-      const response = await dbClient.send(scanCommand);
-      const items = (response.Items || []).map(item => unmarshall(item)) as Material[];
+      do {
+        const queryCommand = new QueryCommand({
+          TableName: MAIN_TABLE,
+          KeyConditionExpression: "PK = :pk",
+          ExpressionAttributeValues: {
+            ":pk": { S: PK_SJUNGUPP },
+          },
+          ExclusiveStartKey: lastEvaluatedKey as Record<string, { S?: string; N?: string }> | undefined,
+        });
+
+        const response = await dbClient.send(queryCommand);
+        const batch = (response.Items || []).map(item => unmarshall(item)) as Material[];
+        allItems.push(...batch);
+        lastEvaluatedKey = response.LastEvaluatedKey as Record<string, unknown> | undefined;
+      } while (lastEvaluatedKey);
+
+      const items = allItems;
 
       // STEG 2: Gruppera materialet per weekId
       const groupedByWeek = items.reduce((acc, material) => {

--- a/packages/material-api/functions/listForMembers.ts
+++ b/packages/material-api/functions/listForMembers.ts
@@ -1,6 +1,6 @@
 // functions/listForMembers.ts
 
-import { DynamoDBClient, ScanCommand } from "@aws-sdk/client-dynamodb";
+import { DynamoDBClient, QueryCommand } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
 import { APIGatewayProxyResultV2 } from "aws-lambda";
 import { sendResponse, sendError } from "../../core/utils/http";
@@ -9,6 +9,8 @@ import { getISOWeek, getYear } from 'date-fns'; // Importera date-fns
 
 const dbClient = new DynamoDBClient({ region: process.env.AWS_REGION });
 const MAIN_TABLE = process.env.MAIN_TABLE;
+
+const PK_SJUNGUPP = "SJUNGUPP#MATERIALS";
 
 interface Material {
   materialId: string;
@@ -35,22 +37,30 @@ export const handler = middy().handler(
       const currentYear = getYear(now);
       const currentWeekNumber = getISOWeek(now);
       const currentWeekId = `${currentYear}-W${String(currentWeekNumber).padStart(2, '0')}`;
-      
-      console.log(`Current week calculated as: ${currentWeekId}`);
 
-      // STEG 2: Hämta allt material som är från nuvarande eller tidigare veckor
-      const scanCommand = new ScanCommand({
-        TableName: MAIN_TABLE,
-        // FilterExpression letar upp rätt typ OCH ser till att weekId är mindre än eller lika med nuvarande vecka
-        FilterExpression: "PK = :pk AND weekId <= :currentWeekId",
-        ExpressionAttributeValues: {
-          ":pk": { S: "SJUNGUPP#MATERIALS" },
-          ":currentWeekId": { S: currentWeekId },
-        },
-      });
+      // STEG 2: Hämta allt Sjungupp-material via Query med FilterExpression för weekId <= currentWeekId
+      const allItems: Material[] = [];
+      let lastEvaluatedKey: Record<string, unknown> | undefined;
 
-      const response = await dbClient.send(scanCommand);
-      const items = (response.Items || []).map(item => unmarshall(item)) as Material[];
+      do {
+        const queryCommand = new QueryCommand({
+          TableName: MAIN_TABLE,
+          KeyConditionExpression: "PK = :pk",
+          FilterExpression: "weekId <= :currentWeekId",
+          ExpressionAttributeValues: {
+            ":pk": { S: PK_SJUNGUPP },
+            ":currentWeekId": { S: currentWeekId },
+          },
+          ExclusiveStartKey: lastEvaluatedKey as Record<string, { S?: string; N?: string }> | undefined,
+        });
+
+        const response = await dbClient.send(queryCommand);
+        const batch = (response.Items || []).map(item => unmarshall(item)) as Material[];
+        allItems.push(...batch);
+        lastEvaluatedKey = response.LastEvaluatedKey as Record<string, unknown> | undefined;
+      } while (lastEvaluatedKey);
+
+      const items = allItems;
 
       // STEG 3: Gruppera och sortera (samma logik som i listByWeek)
       const groupedByWeek = items.reduce((acc, material) => {

--- a/packages/material-api/yaml/material-functions.yml
+++ b/packages/material-api/yaml/material-functions.yml
@@ -480,6 +480,7 @@ listPracticeByWeek:
   iamRoleStatements:
     - Effect: "Allow"
       Action:
+        - dynamodb:Query
         - dynamodb:Scan
       Resource:
         - "arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.mainTableName}"
@@ -499,6 +500,7 @@ listPracticeForMembers:
     iamRoleStatements:
       - Effect: "Allow"
         Action:
+          - dynamodb:Query
           - dynamodb:Scan
         Resource:
           - "arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.mainTableName}"


### PR DESCRIPTION
…terials

- listByWeek: Query on PK=SJUNGUPP#MATERIALS with pagination so all items are returned
- listForMembers: same Query + FilterExpression weekId<=currentWeekId, with pagination
- Add dynamodb:Query to IAM for listPracticeByWeek and listPracticeForMembers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes DynamoDB access patterns for two listing endpoints (Scan→Query) and adds pagination, which could affect which items are returned if key schema/PK assumptions differ. IAM is updated to allow `dynamodb:Query`, but runtime behavior now depends on correct partition key usage and pagination handling.
> 
> **Overview**
> **Improves Sjungupp practice material listing performance and completeness** by switching `listByWeek` and `listForMembers` from DynamoDB `Scan` to partition-key `Query` on `PK = "SJUNGUPP#MATERIALS"`.
> 
> Both handlers now **paginate through all Query results** using `LastEvaluatedKey`; `listForMembers` keeps the `weekId <= currentWeekId` constraint via `FilterExpression`. Serverless IAM for `listPracticeByWeek` and `listPracticeForMembers` is updated to include `dynamodb:Query` permissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3436a524267b93ac301d390291133d8a31251c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->