### PR TITLE
fix(admin-api): paginate group list Scan so all groups are returned

### DIFF
--- a/packages/admin-api/functions/group/list.ts
+++ b/packages/admin-api/functions/group/list.ts
@@ -6,6 +6,7 @@ import {
 } from "aws-lambda";
 import { DynamoDBClient, ScanCommand } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
+import type { AttributeValue } from "@aws-sdk/client-dynamodb";
 
 const dbClient = new DynamoDBClient({ region: process.env.AWS_REGION });
 
@@ -14,21 +15,26 @@ export const handler = middy().handler(
     event: APIGatewayProxyEventV2WithLambdaAuthorizer<any>
   ): Promise<APIGatewayProxyResultV2> => {
     try {
-      // Hämta alla grupper från DynamoDB
-      const scanCommand = new ScanCommand({
-        TableName: process.env.MAIN_TABLE as string,
-        FilterExpression: "begins_with(PK, :prefix) AND SK = :metadata",
-        ExpressionAttributeValues: {
-          ":prefix": { S: "GROUP#" },
-          ":metadata": { S: "METADATA" },
-        },
-      });
+      const allItems: Record<string, AttributeValue>[] = [];
+      let lastEvaluatedKey: Record<string, AttributeValue> | undefined;
 
-      const response = await dbClient.send(scanCommand);
-      const items = response.Items || [];
+      do {
+        const scanCommand = new ScanCommand({
+          TableName: process.env.MAIN_TABLE as string,
+          FilterExpression: "begins_with(PK, :prefix) AND SK = :metadata",
+          ExpressionAttributeValues: {
+            ":prefix": { S: "GROUP#" },
+            ":metadata": { S: "METADATA" },
+          },
+          ExclusiveStartKey: lastEvaluatedKey,
+        });
 
-      // Avkodar dynamo-objekten till vanliga JS-objekt
-      const groups = items.map(item => unmarshall(item));
+        const response = await dbClient.send(scanCommand);
+        allItems.push(...(response.Items || []));
+        lastEvaluatedKey = response.LastEvaluatedKey;
+      } while (lastEvaluatedKey);
+
+      const groups = allItems.map(item => unmarshall(item));
 
       return sendResponse(groups, 200);
     } catch (error: any) {

--- a/packages/admin-api/functions/group/listPublic.ts
+++ b/packages/admin-api/functions/group/listPublic.ts
@@ -3,43 +3,47 @@
 import middy from "@middy/core";
 import { sendResponse, sendError } from "../../../core/utils/http";
 import {
-  APIGatewayProxyEventV2, // Ändrad till en enklare typ då vi inte behöver authorizer-data
+  APIGatewayProxyEventV2,
   APIGatewayProxyResultV2,
 } from "aws-lambda";
 import { DynamoDBClient, ScanCommand } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
+import type { AttributeValue } from "@aws-sdk/client-dynamodb";
 
 const dbClient = new DynamoDBClient({ region: process.env.AWS_REGION });
 
-// Denna funktion är avsedd att exponeras för alla inloggade användare (user, leader).
 export const handler = middy().handler(
   async (
     event: APIGatewayProxyEventV2
   ): Promise<APIGatewayProxyResultV2> => {
     try {
-      const scanCommand = new ScanCommand({
-        TableName: process.env.MAIN_TABLE as string,
-        FilterExpression: "begins_with(PK, :prefix) AND SK = :metadata",
-        ExpressionAttributeValues: {
-          ":prefix": { S: "GROUP#" },
-          ":metadata": { S: "METADATA" },
-        },
-        // FÖRBÄTTRING: Detta är den viktiga ändringen.
-        // Vi talar om för DynamoDB att BARA hämta dessa tre attribut.
-        // Detta är både säkrare och mer kostnadseffektivt.
-        ProjectionExpression: "#n, #s, #l , #c",
-        ExpressionAttributeNames: {
-          "#n": "name",
-          "#s": "slug",
-          "#l": "location",
-          "#c": "choirLeader",
-        },
-      });
+      const allItems: Record<string, AttributeValue>[] = [];
+      let lastEvaluatedKey: Record<string, AttributeValue> | undefined;
 
-      const response = await dbClient.send(scanCommand);
-      const items = response.Items || [];
-      
-      const groups = items.map(item => unmarshall(item));
+      do {
+        const scanCommand = new ScanCommand({
+          TableName: process.env.MAIN_TABLE as string,
+          FilterExpression: "begins_with(PK, :prefix) AND SK = :metadata",
+          ExpressionAttributeValues: {
+            ":prefix": { S: "GROUP#" },
+            ":metadata": { S: "METADATA" },
+          },
+          ProjectionExpression: "#n, #s, #l, #c",
+          ExpressionAttributeNames: {
+            "#n": "name",
+            "#s": "slug",
+            "#l": "location",
+            "#c": "choirLeader",
+          },
+          ExclusiveStartKey: lastEvaluatedKey,
+        });
+
+        const response = await dbClient.send(scanCommand);
+        allItems.push(...(response.Items || []));
+        lastEvaluatedKey = response.LastEvaluatedKey;
+      } while (lastEvaluatedKey);
+
+      const groups = allItems.map(item => unmarshall(item));
 
       return sendResponse(groups, 200);
     } catch (error: any) {


### PR DESCRIPTION
- group/list: loop with LastEvaluatedKey/ExclusiveStartKey to fetch all pages
- group/listPublic: same pagination; keeps ProjectionExpression for name, slug, location, choirLeader
- Fixes groups missing from list when table grows (e.g. Boråskören)