### PR TITLE
feat(frontend): unify music widget for member, leader, and admin

### DIFF
--- a/packages/frontend/src/components/layout/GroupDashboardLayout.module.scss
+++ b/packages/frontend/src/components/layout/GroupDashboardLayout.module.scss
@@ -8,8 +8,17 @@
   padding-bottom: var(--spacing-lg);
 }
 
+.groupNameRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+}
+
 .groupName {
-  margin: 0 0 var(--spacing-md) 0;
+  margin: 0;
   font-size: var(--fs-lg, 1.25rem);
   font-weight: 700;
   color: var(--color-text);

--- a/packages/frontend/src/components/layout/GroupDashboardLayout.tsx
+++ b/packages/frontend/src/components/layout/GroupDashboardLayout.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { Outlet, useParams } from 'react-router-dom';
 import { GroupNav } from '@/components/ui/nav/GroupNav';
+import { RecentlyPlayedWidget } from '@/components/music/RecentlyPlayedWidget';
 import axios from 'axios';
 import styles from './GroupDashboardLayout.module.scss';
 
@@ -63,7 +64,12 @@ export const GroupDashboardLayout = () => {
     >
       <div className={styles.dashboardLayout}>
         <header className={styles.header}>
-          <h1 className={styles.groupName}>{currentGroup.name}</h1>
+          <div className={styles.groupNameRow}>
+            <h1 className={styles.groupName}>{currentGroup.name}</h1>
+            {groupSlug ? (
+              <RecentlyPlayedWidget groupName={groupSlug} viewer="admin" />
+            ) : null}
+          </div>
           <GroupNav />
         </header>
         <main className={styles.content}>

--- a/packages/frontend/src/components/music/RecentlyPlayedWidget.tsx
+++ b/packages/frontend/src/components/music/RecentlyPlayedWidget.tsx
@@ -1,17 +1,25 @@
 import { Play } from 'lucide-react';
-import { useMusicPlayerOverlay } from '@/context/MusicPlayerOverlayContext';
+import {
+  useMusicPlayerOverlay,
+  type MusicPlayerViewer,
+} from '@/context/MusicPlayerOverlayContext';
 import { useRecentlyPlayed } from '@/hooks/useRecentlyPlayed';
 import { entryToResumePayload } from '@/utils/recentPlayback';
 import styles from './RecentlyPlayedWidget.module.scss';
 
 export interface RecentlyPlayedWidgetProps {
   groupName: string | undefined;
+  /** Vilken vy som öppnar spelaren (styr länkar tillbaka till repertoar m.m.). */
+  viewer?: MusicPlayerViewer;
 }
 
 /**
  * Visar senaste spår för kören (localStorage) eller en "Utforska musik"-CTA.
  */
-export function RecentlyPlayedWidget({ groupName }: RecentlyPlayedWidgetProps) {
+export function RecentlyPlayedWidget({
+  groupName,
+  viewer = 'member',
+}: RecentlyPlayedWidgetProps) {
   const entry = useRecentlyPlayed(groupName);
   const {
     open: openMusicOverlay,
@@ -29,14 +37,14 @@ export function RecentlyPlayedWidget({ groupName }: RecentlyPlayedWidgetProps) {
   const resume = entry ? entryToResumePayload(entry) : null;
 
   const handleCardClick = () => {
-    if (activeGroupName === g && activeViewer === 'member' && !isOpen) {
+    if (activeGroupName === g && activeViewer === viewer && !isOpen) {
       expandOverlay();
       return;
     }
     if (hasRecent && resume) {
-      openMusicOverlay(g, 'member', { playbackIntent: 'browse', resume });
+      openMusicOverlay(g, viewer, { playbackIntent: 'browse', resume });
     } else {
-      openMusicOverlay(g, 'member', { playbackIntent: 'browse' });
+      openMusicOverlay(g, viewer, { playbackIntent: 'browse' });
     }
   };
 
@@ -45,20 +53,20 @@ export function RecentlyPlayedWidget({ groupName }: RecentlyPlayedWidgetProps) {
     e.stopPropagation();
     if (hasRecent && resume) {
       if (resume.source === 'repertoire') {
-        openMusicOverlay(g, 'member', {
+        openMusicOverlay(g, viewer, {
           startMinimized: true,
           initialRepertoireId: resume.repertoireId,
           playbackIntent: { type: 'fromMaterialId', materialId: resume.materialId },
         });
       } else {
-        openMusicOverlay(g, 'member', {
+        openMusicOverlay(g, viewer, {
           startMinimized: true,
           initialPlaylistId: resume.playlistId,
           playbackIntent: { type: 'fromMaterialId', materialId: resume.materialId },
         });
       }
     } else {
-      openMusicOverlay(g, 'member', { startMinimized: true, playbackIntent: 'playAll' });
+      openMusicOverlay(g, viewer, { startMinimized: true, playbackIntent: 'playAll' });
     }
   };
 

--- a/packages/frontend/src/context/MusicPlayerOverlayContext.tsx
+++ b/packages/frontend/src/context/MusicPlayerOverlayContext.tsx
@@ -23,7 +23,7 @@ export type {
   RepertoirePlaybackIntent,
 } from '@/utils/recentPlayback';
 
-export type MusicPlayerViewer = 'member' | 'leader';
+export type MusicPlayerViewer = 'member' | 'leader' | 'admin';
 
 /** Hur spelläget för favoriter/bibliotek ska starta uppspelning */
 export type LibraryPlaybackIntent =

--- a/packages/frontend/src/pages/leader/LeaderDashboard.module.scss
+++ b/packages/frontend/src/pages/leader/LeaderDashboard.module.scss
@@ -35,26 +35,3 @@
     font-weight: 700;
     color: var(--color-text);
   }
-
-  .musicShortcut {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.85rem;
-    border-radius: 999px;
-    border: 1px solid var(--color-border);
-    background: rgba(255, 255, 255, 0.04);
-    color: var(--color-text);
-    text-decoration: none;
-    font-size: var(--fs-sm, 0.9rem);
-    font-weight: 500;
-    cursor: pointer;
-    font-family: inherit;
-    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
-
-    &:hover {
-      background: rgba(255, 255, 255, 0.08);
-      border-color: var(--color-primary);
-      color: var(--color-primary);
-    }
-  }

--- a/packages/frontend/src/pages/leader/LeaderDashboard.tsx
+++ b/packages/frontend/src/pages/leader/LeaderDashboard.tsx
@@ -1,7 +1,6 @@
 import { Outlet, useParams } from 'react-router-dom';
-import { Music } from 'lucide-react';
 import { useAuth } from '@/context/AuthContext';
-import { useMusicPlayerOverlay } from '@/context/MusicPlayerOverlayContext';
+import { RecentlyPlayedWidget } from '@/components/music/RecentlyPlayedWidget';
 import { LeaderNav } from '@/components/ui/nav/LeaderNav';
 import styles from './LeaderDashboard.module.scss';
 import { useState, useEffect } from 'react';
@@ -17,7 +16,6 @@ interface Group {
 export const LeaderDashboard = () => {
   const { groupName } = useParams<{ groupName: string }>();
   const { user } = useAuth();
-  const { open: openMusicOverlay } = useMusicPlayerOverlay();
   const [choirDisplayName, setChoirDisplayName] = useState('');
   const [isLoadingName, setIsLoadingName] = useState(true);
 
@@ -72,15 +70,7 @@ export const LeaderDashboard = () => {
       {!isLoadingName && choirDisplayName && groupName && (
         <div className={styles.groupNameRow}>
           <h1 className={styles.groupName}>{choirDisplayName}</h1>
-          <button
-            type="button"
-            className={styles.musicShortcut}
-            title="Öppna musikspelaren"
-            onClick={() => openMusicOverlay(groupName, 'leader')}
-          >
-            <Music size={20} aria-hidden />
-            <span>Musikspelaren</span>
-          </button>
+          <RecentlyPlayedWidget groupName={groupName} viewer="leader" />
         </div>
       )}
       <LeaderNav />

--- a/packages/frontend/src/pages/member/MemberDashboard.tsx
+++ b/packages/frontend/src/pages/member/MemberDashboard.tsx
@@ -77,7 +77,7 @@ export const MemberDashboard = () => {
       {!isLoadingName && choirDisplayName && groupName && (
         <div className={styles.groupNameRow}>
           <h2 className={styles.groupName}>{choirDisplayName}</h2>
-          <RecentlyPlayedWidget groupName={groupName} />
+          <RecentlyPlayedWidget groupName={groupName} viewer="member" />
         </div>
       )}
       <UserNav groupName={groupName} />

--- a/packages/frontend/src/pages/member/MusicDeepLinkHandler.tsx
+++ b/packages/frontend/src/pages/member/MusicDeepLinkHandler.tsx
@@ -28,7 +28,9 @@ export function MusicDeepLinkHandler({ viewer }: MusicDeepLinkHandlerProps) {
     const dest =
       viewer === 'leader'
         ? `/leader/choir/${g}/repertoires`
-        : `/user/me/${g}/repertoires`;
+        : viewer === 'admin'
+          ? `/admin/groups/${g}/repertoires`
+          : `/user/me/${g}/repertoires`;
     navigate(dest, { replace: true });
   }, [groupName, viewer, navigate, open]);
 

--- a/packages/frontend/src/pages/member/RepertoireMusicPlayerPanel.tsx
+++ b/packages/frontend/src/pages/member/RepertoireMusicPlayerPanel.tsx
@@ -213,9 +213,9 @@ export function RepertoireMusicPlayerPanel({
 
   const repertoiresHref = useMemo(() => {
     if (!groupName) return "/";
-    return viewer === "leader"
-      ? `/leader/choir/${groupName}/repertoires`
-      : `/user/me/${groupName}/repertoires`;
+    if (viewer === "leader") return `/leader/choir/${groupName}/repertoires`;
+    if (viewer === "admin") return `/admin/groups/${groupName}/repertoires`;
+    return `/user/me/${groupName}/repertoires`;
   }, [groupName, viewer]);
 
   const audioMaterials = useMemo(

--- a/packages/frontend/src/routes/Router.tsx
+++ b/packages/frontend/src/routes/Router.tsx
@@ -123,6 +123,7 @@ const router = createBrowserRouter([
                   { path: "practice", element: <PracticePage /> },
                   { path: "users", element: <AdminUserManagementPage viewerRole="admin" /> },
                   { path: "attendance", element: <LeaderAttendancePage /> },
+                  { path: "music", element: <MusicDeepLinkHandler viewer="admin" /> },
                 ],
               },
             ],


### PR DESCRIPTION
- RecentlyPlayedWidget accepts viewer; MusicPlayerViewer includes admin for correct repertoire URLs.

- LeaderDashboard uses same widget as members; GroupDashboardLayout shows widget for admins.

- MusicDeepLinkHandler and RepertoireMusicPlayerPanel handle admin paths; Router adds admin groups music route.