### PR TITLE
fix(media-library): S3 delete IAM, batch-delete flow, and global mate…

### DIFF
--- a/packages/frontend/src/pages/admin/AdminUploadMaterialPage.module.scss
+++ b/packages/frontend/src/pages/admin/AdminUploadMaterialPage.module.scss
@@ -176,15 +176,3 @@
   }
 }
 
-/* --- Anpassningar för större skärmar (Desktop) --- */
-@media (min-width: #{$tabletBreakpoint}) {
-  .deleteButton {
-    visibility: hidden;
-    opacity: 0;
-  }
-
-  .materialItem:hover .deleteButton {
-    visibility: visible;
-    opacity: 1;
-  }
-}

--- a/packages/frontend/src/pages/admin/AdminUploadMaterialPage.tsx
+++ b/packages/frontend/src/pages/admin/AdminUploadMaterialPage.tsx
@@ -47,6 +47,22 @@ const getAllMaterialIdsInFolder = (folderNode: FolderNode): string[] => {
   );
 };
 
+/** Undvik API Gateway/Lambda-timeout vid många filer; backend processar redan i chunk om 25. */
+const BATCH_DELETE_MAX_IDS = 150;
+
+function apiErrorMessage(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const err = error as { response?: { data?: unknown; status?: number }; code?: string };
+  const data = err.response?.data;
+  if (data && typeof data === 'object' && data !== null && 'message' in data && typeof (data as { message: string }).message === 'string') {
+    return (data as { message: string }).message;
+  }
+  if (err.response?.status === 504 || err.code === 'ECONNABORTED') {
+    return 'Begäran tog för länge. Försök igen; vid många filer raderas de nu i flera omgångar.';
+  }
+  return undefined;
+}
+
 // --- KOMPONENT FÖR MAPP-RADER (Flyttad utanför huvudkomponenten) ---
 interface MaterialFolderItemProps {
   node: FolderNode;
@@ -159,11 +175,22 @@ export const AdminUploadMaterialPage = () => {
     setStatusMessage(null);
     const token = localStorage.getItem('authToken');
     try {
-      await axios.post(`${API_BASE_URL}/materials/batch-delete`, { materialIds: ids }, { headers: { Authorization: `Bearer ${token}` } });
+      for (let i = 0; i < ids.length; i += BATCH_DELETE_MAX_IDS) {
+        const chunk = ids.slice(i, i + BATCH_DELETE_MAX_IDS);
+        await axios.post(
+          `${API_BASE_URL}/materials/batch-delete`,
+          { materialIds: chunk },
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
+      }
       setStatusMessage({ type: 'success', message: `Mappen "${folderName}" har raderats.` });
       await fetchMaterials(); // Hämta den uppdaterade listan
     } catch (error) {
-      setStatusMessage({ type: 'error', message: 'Kunde inte radera mappen.' });
+      const detail = apiErrorMessage(error);
+      setStatusMessage({
+        type: 'error',
+        message: detail ?? 'Kunde inte radera mappen.',
+      });
     } finally {
       setDeletingFolder(null); // CHANGED: Nollställ oavsett resultat
     }

--- a/packages/material-api/functions/batchDeleteGlobalMaterials.ts
+++ b/packages/material-api/functions/batchDeleteGlobalMaterials.ts
@@ -9,15 +9,12 @@ import { S3Client, DeleteObjectsCommand, ObjectIdentifier } from "@aws-sdk/clien
 import { unmarshall } from "@aws-sdk/util-dynamodb";
 import { APIGatewayProxyEvent, APIGatewayProxyResultV2 } from "aws-lambda";
 import { sendResponse, sendError } from "../../core/utils/http";
-import { CognitoIdentityProviderClient, AdminGetUserCommand } from "@aws-sdk/client-cognito-identity-provider";
 
 const dbClient = new DynamoDBClient({ region: process.env.AWS_REGION });
 const s3Client = new S3Client({ region: process.env.AWS_REGION });
-const cognitoClient = new CognitoIdentityProviderClient({ region: process.env.AWS_REGION });
 
 const MAIN_TABLE = process.env.MAIN_TABLE;
 const BUCKET_NAME = process.env.MEDIA_BUCKET_NAME;
-const COGNITO_USER_POOL_ID = process.env.COGNITO_USER_POOL_ID;
 
 const BATCH_SIZE = 25;
 const MAX_RETRIES = 5;
@@ -95,26 +92,26 @@ async function batchWriteDeletesWithRetry(writeRequests: WriteRequest[]): Promis
 export const handler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResultV2> => {
-  if (!MAIN_TABLE || !BUCKET_NAME || !COGNITO_USER_POOL_ID) {
+  if (!MAIN_TABLE || !BUCKET_NAME) {
     return sendError(500, "Server configuration error.");
   }
 
   try {
-    const userId = event.requestContext.authorizer?.lambda?.uuid;
-    if (!userId) {
-      return sendError(403, "Forbidden: User not identifiable.");
-    }
-    const userCommand = new AdminGetUserCommand({ UserPoolId: COGNITO_USER_POOL_ID, Username: userId });
-    const userResponse = await cognitoClient.send(userCommand);
-    const roleAttribute = userResponse.UserAttributes?.find((attr) => attr.Name === "custom:role");
-    if (roleAttribute?.Value !== "admin") {
+    const role = event.requestContext.authorizer?.lambda?.role as string | undefined;
+    if (role !== "admin") {
       return sendError(403, "Forbidden: You do not have permission.");
     }
 
     if (!event.body) {
       return sendError(400, "Request body is required.");
     }
-    const { materialIds: rawIds } = JSON.parse(event.body) as { materialIds?: unknown };
+    let parsed: { materialIds?: unknown };
+    try {
+      parsed = JSON.parse(event.body) as { materialIds?: unknown };
+    } catch {
+      return sendError(400, "Invalid JSON body.");
+    }
+    const { materialIds: rawIds } = parsed;
     if (!Array.isArray(rawIds) || rawIds.length === 0) {
       return sendError(400, "An array of materialIds is required.");
     }
@@ -166,10 +163,11 @@ export const handler = async (
         .map((r) => r.materialId)
         .filter((mid): mid is string => typeof mid === "string" && mid.length > 0);
 
-      const keysToDeleteFromS3: ObjectIdentifier[] = globalRows
+      const s3Keys = globalRows
         .map((item) => item.fileKey)
-        .filter((k): k is string => typeof k === "string" && k.length > 0)
-        .map((key) => ({ Key: key }));
+        .filter((k): k is string => typeof k === "string" && k.length > 0);
+      const uniqueKeys = [...new Set(s3Keys)];
+      const keysToDeleteFromS3: ObjectIdentifier[] = uniqueKeys.map((key) => ({ Key: key }));
 
       if (keysToDeleteFromS3.length > 0) {
         const delResult = await s3Client.send(

--- a/packages/material-api/functions/listAllGlobalMaterials.ts
+++ b/packages/material-api/functions/listAllGlobalMaterials.ts
@@ -1,7 +1,11 @@
-import { DynamoDBClient, QueryCommand } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBClient,
+  QueryCommand,
+  type AttributeValue,
+} from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
 import { APIGatewayProxyResultV2 } from "aws-lambda";
-import { sendResponse, sendError } from "../../core/utils/http"; 
+import { sendResponse, sendError } from "../../core/utils/http";
 
 const dbClient = new DynamoDBClient({ region: process.env.AWS_REGION });
 const MAIN_TABLE = process.env.MAIN_TABLE;
@@ -12,25 +16,31 @@ export const handler = async (): Promise<APIGatewayProxyResultV2> => {
   }
 
   try {
-    
-    // Detta kommando siktar på GSI1 istället för huvudnyckeln.
-    const command = new QueryCommand({
-      TableName: MAIN_TABLE,
-      IndexName: 'GSI1', 
-      KeyConditionExpression: "GSI1PK = :gsi1pk", 
-      ExpressionAttributeValues: {
-        ":gsi1pk": { S: "MATERIALS" }, 
-      },
-      
-      ScanIndexForward: false, 
-    });
+    const materials: Record<string, unknown>[] = [];
+    let exclusiveStartKey: Record<string, AttributeValue> | undefined;
 
-    const { Items } = await dbClient.send(command);
-    
-    const materials = (Items || []).map(item => unmarshall(item));
+    do {
+      const command = new QueryCommand({
+        TableName: MAIN_TABLE,
+        IndexName: "GSI1",
+        KeyConditionExpression: "GSI1PK = :gsi1pk",
+        ExpressionAttributeValues: {
+          ":gsi1pk": { S: "MATERIALS" },
+        },
+        ScanIndexForward: false,
+        ExclusiveStartKey: exclusiveStartKey,
+      });
+
+      const { Items, LastEvaluatedKey } = await dbClient.send(command);
+
+      for (const item of Items ?? []) {
+        materials.push(unmarshall(item));
+      }
+
+      exclusiveStartKey = LastEvaluatedKey;
+    } while (exclusiveStartKey);
 
     return sendResponse(materials, 200);
-
   } catch (error: any) {
     console.error("Error fetching all global materials:", error);
     return sendError(500, error.message || "Internal server error");

--- a/packages/material-api/yaml/material-functions.yml
+++ b/packages/material-api/yaml/material-functions.yml
@@ -213,6 +213,9 @@ batchDeleteGlobalMaterials:
     handler: functions/batchDeleteGlobalMaterials.handler
     name: hrk-batch-delete-global-materials-${sls:stage}
     description: Deletes multiple global materials from DynamoDB and S3. (Admin only)
+    # HTTP API Lambda-integration max ~30s; default Lambda 6s is too low for large folders.
+    timeout: 29
+    memorySize: 512
     events:
       - httpApi:
           method: POST # Använder POST för att kunna skicka med en body
@@ -222,7 +225,6 @@ batchDeleteGlobalMaterials:
     environment:
       MAIN_TABLE: ${self:custom.mainTableName}
       MEDIA_BUCKET_NAME: ${self:custom.mediaBucketName}
-      COGNITO_USER_POOL_ID: ${self:custom.userPoolId}
     iamRoleStatements:
       - Effect: "Allow"
         Action:
@@ -231,11 +233,8 @@ batchDeleteGlobalMaterials:
         Resource: ["arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.mainTableName}"]
       - Effect: "Allow"
         Action:
-          - "s3:DeleteObjects"        # Ny, effektivare behörighet
+          - "s3:DeleteObject"
         Resource: ["arn:aws:s3:::${self:custom.mediaBucketName}/*"]
-      - Effect: "Allow"
-        Action: ["cognito-idp:AdminGetUser"]
-        Resource: ["arn:aws:cognito-idp:${self:provider.region}:${aws:accountId}:userpool/${self:custom.userPoolId}"]
 
 createRepertoire:
   handler: functions/createRepertoire.handler
@@ -470,7 +469,7 @@ batchDeletePracticeMaterials:
         Resource: ["arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.mainTableName}"]
       - Effect: "Allow"
         Action:
-          - "s3:DeleteObjects"        # Ny, effektivare behörighet
+          - "s3:DeleteObject"
         Resource: ["arn:aws:s3:::${self:custom.mediaBucketName}/*"]
       - Effect: "Allow"
         Action: ["cognito-idp:AdminGetUser"]


### PR DESCRIPTION
…rials list

- Grant s3:DeleteObject for batch delete Lambdas; raise timeout/memory on global batch-delete
- Authorize global batch-delete via JWT authorizer role; dedupe S3 keys; validate JSON body
- Paginate GSI query in listAllGlobalMaterials for full library results
- Chunk client batch-delete requests; surface API errors; always show folder delete control