### PR TITLE
feat(frontend): keep music playing while navigating the app

### DIFF
--- a/packages/frontend/src/components/music/MusicPlayerOverlay.tsx
+++ b/packages/frontend/src/components/music/MusicPlayerOverlay.tsx
@@ -17,7 +17,6 @@ interface MusicPlayerOverlayProps {
   /** När false: fullskärms-UI döljs men panelen (och MediaPlayer) monteras kvar för miniplayer. */
   overlayUiVisible: boolean;
   onCloseOverlay: () => void;
-  onExitSession: () => void;
   libraryQueueMaterials?: Material[] | null;
   libraryPlaybackIntent?: LibraryPlaybackIntent | null;
   /** Sjung upp m.m.: bibliotekskö men repertoar-sidebar ska visas. */
@@ -40,7 +39,6 @@ export function MusicPlayerOverlay({
   viewer,
   overlayUiVisible,
   onCloseOverlay,
-  onExitSession,
   libraryQueueMaterials,
   libraryPlaybackIntent,
   libraryPlaybackWithRepertoire = false,
@@ -127,7 +125,7 @@ export function MusicPlayerOverlay({
       <button
         type="button"
         className={styles.scrim}
-        aria-label="Stäng musik (samma som Esc)"
+        aria-label="Minimera musikspelare (samma som Esc)"
         onClick={onCloseOverlay}
         tabIndex={overlayUiVisible ? 0 : -1}
       />
@@ -143,7 +141,6 @@ export function MusicPlayerOverlay({
           groupName={groupName}
           viewer={viewer}
           onMinimizeOverlay={onCloseOverlay}
-          onExitSession={onExitSession}
           shellTitleId={titleId}
           libraryQueueMaterials={libraryQueueMaterials ?? null}
           libraryPlaybackIntent={libraryPlaybackIntent ?? null}
@@ -166,7 +163,6 @@ export function MusicPlayerOverlayHost({ mountEl }: { mountEl?: HTMLElement | nu
     activeGroupName,
     activeViewer,
     closeOverlay,
-    closeSession,
     libraryMaterials,
     libraryPlayback,
     libraryPlaybackWithRepertoire,
@@ -185,7 +181,6 @@ export function MusicPlayerOverlayHost({ mountEl }: { mountEl?: HTMLElement | nu
       viewer={activeViewer}
       overlayUiVisible={isOpen}
       onCloseOverlay={closeOverlay}
-      onExitSession={closeSession}
       libraryQueueMaterials={libraryMaterials ?? undefined}
       libraryPlaybackIntent={libraryPlayback ?? undefined}
       libraryPlaybackWithRepertoire={libraryPlaybackWithRepertoire}

--- a/packages/frontend/src/pages/admin/AdminRepertoireMaterialPage.module.scss
+++ b/packages/frontend/src/pages/admin/AdminRepertoireMaterialPage.module.scss
@@ -194,7 +194,13 @@
     }
   }
 
-  [aria-label^="Spela"] { color: var(--color-icon-play); }
+  [aria-label^="Spela"] {
+    color: var(--color-icon-play);
+
+    &[aria-pressed='true'] {
+      color: var(--color-primary);
+    }
+  }
   [aria-label^="Visa"] { color: var(--color-icon-view); }
   [aria-label^="Ta bort"] { color: var(--color-text-secondary); 
     &:hover {

--- a/packages/frontend/src/pages/admin/AdminRepertoireMaterialPage.tsx
+++ b/packages/frontend/src/pages/admin/AdminRepertoireMaterialPage.tsx
@@ -7,7 +7,11 @@ import { FiFolder, FiMusic, FiFileText, FiFile, FiChevronRight, FiArrowLeft } fr
 import styles from './AdminRepertoireMaterialPage.module.scss';
 import type { Material } from '@/types';
 import { MediaModal } from '@/components/ui/modal/MediaModal';
-import { MediaPlayer } from '@/components/media/MediaPlayer';
+import {
+  useMusicPlayerOverlay,
+  type MusicPlayerViewer,
+} from '@/context/MusicPlayerOverlayContext';
+import { isPlayableAudioFile } from '@/utils/media';
 
 // --- TYPER ---
 // FIX: Lade till 'displayName' för att visa ett städat mappnamn.
@@ -21,7 +25,12 @@ interface FileItem { type: 'file'; material: Material; }
 type DirectoryItem = FolderItem | FileItem;
 
 const API_BASE_URL = import.meta.env.VITE_MATERIAL_API_URL;
-const FILE_BASE_URL = import.meta.env.VITE_S3_BUCKET_URL;
+
+function musicViewerFromPathname(pathname: string): MusicPlayerViewer {
+  if (pathname.startsWith('/leader/')) return 'leader';
+  if (pathname.startsWith('/admin/')) return 'admin';
+  return 'member';
+}
 
 // --- HJÄLPFUNKTIONER ---
 const getIconForFile = (fileName: string = '') => {
@@ -159,14 +168,19 @@ export const AdminRepertoireMaterialPage = () => {
   const splat = useParams()['*'];
   const location = useLocation();
   const navigate = useNavigate();
+  const { open: openMusicOverlay, activeMaterialId, isPlaying, activeGroupName } =
+    useMusicPlayerOverlay();
+  const viewer = musicViewerFromPathname(location.pathname);
   
   const [title, setTitle] = useState(location.state?.repertoireTitle);
   const [linkedMaterials, setLinkedMaterials] = useState<Material[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const [nowPlaying, setNowPlaying] = useState<{ url: string; title: string; } | null>(null);
   const [materialToView, setMaterialToView] = useState<Material | null>(null);
+
+  const sessionMatchesThisGroup =
+    Boolean(groupName?.trim()) && activeGroupName === groupName?.trim();
   
   const fetchLinkedMaterials = useCallback(async () => {
     if (!groupName || !repertoireId) return;
@@ -223,6 +237,21 @@ export const AdminRepertoireMaterialPage = () => {
   
   const breadcrumbs = useMemo(() => decodedSubPath.split('/').filter(p => p), [decodedSubPath]);
   const currentTitle = breadcrumbs.length > 0 ? breadcrumbs[breadcrumbs.length - 1] : title;
+
+  const handlePlayMaterial = useCallback(
+    (material: Material) => {
+      const g = groupName?.trim();
+      const rep = repertoireId?.trim();
+      if (!g || !rep || !material.materialId?.trim()) return;
+      if (!material.fileKey || !isPlayableAudioFile(material.fileKey)) return;
+      openMusicOverlay(g, viewer, {
+        initialRepertoireId: rep,
+        repertoirePlayback: { type: 'fromMaterialId', materialId: material.materialId.trim() },
+        startMinimized: true,
+      });
+    },
+    [groupName, repertoireId, viewer, openMusicOverlay]
+  );
 
   const handleSmartBack = () => {
     if (decodedSubPath) {
@@ -294,13 +323,14 @@ export const AdminRepertoireMaterialPage = () => {
                 <div className={styles.actions}>
                   {isAudioFile(item.material.fileKey) && (
                     <button
-                      onClick={() => setNowPlaying({
-                        url: `${FILE_BASE_URL}/${item.material.fileKey}`,
-                        title: item.material.title || item.material.fileKey || ''
-                      })}
-                      className={styles.iconPlay}
+                      onClick={() => handlePlayMaterial(item.material)}
                       title={`Spela upp ${item.material.title || (item.material.filePath || item.material.fileKey || '').split('/').pop()}`}
                       aria-label={`Spela upp ${item.material.title || (item.material.filePath || item.material.fileKey || '').split('/').pop()}`}
+                      aria-pressed={
+                        sessionMatchesThisGroup &&
+                        activeMaterialId === item.material.materialId &&
+                        isPlaying
+                      }
                     >
                       <FaPlayCircle size={22} />
                     </button>
@@ -324,7 +354,6 @@ export const AdminRepertoireMaterialPage = () => {
         )}
       </div>
 
-      {nowPlaying && <MediaPlayer key={nowPlaying.url} src={nowPlaying.url} title={nowPlaying.title} />}
       {materialToView && <MediaModal isOpen={!!materialToView} onClose={() => setMaterialToView(null)} material={materialToView} />}
     </div>
   );

--- a/packages/frontend/src/pages/member/RepertoireMusicPlayerPage.module.scss
+++ b/packages/frontend/src/pages/member/RepertoireMusicPlayerPage.module.scss
@@ -70,28 +70,6 @@
   gap: 6px;
 }
 
-.backLink {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  color: #a0a0a0;
-  text-decoration: none;
-  font-size: 0.8rem;
-  font-weight: 500;
-  padding: 6px 12px;
-  border-radius: 999px;
-  border: none;
-  background: none;
-  cursor: pointer;
-  font-family: inherit;
-  transition: color 0.15s, background 0.15s;
-
-  &:hover {
-    color: #fff;
-    background: rgba(255, 255, 255, 0.07);
-  }
-}
-
 .closeButton {
   display: inline-flex;
   align-items: center;
@@ -1587,11 +1565,6 @@ $trackUiFont:
 
   .shellTopRight {
     gap: 4px;
-  }
-
-  .backLink {
-    padding: 6px 8px;
-    font-size: 0.72rem;
   }
 
   .closeButton {

--- a/packages/frontend/src/pages/member/RepertoireMusicPlayerPanel.tsx
+++ b/packages/frontend/src/pages/member/RepertoireMusicPlayerPanel.tsx
@@ -7,7 +7,6 @@ import {
   useRef,
 } from "react";
 import { createPortal } from "react-dom";
-import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import {
   Music,
@@ -73,10 +72,8 @@ interface RepertoireItem {
 export interface RepertoireMusicPlayerPanelProps {
   groupName: string;
   viewer: MusicPlayerViewer;
-  /** Stänger endast fullskärm (miniplayer fortsätter). */
+  /** Stänger fullskärm (miniplayer fortsätter). */
   onMinimizeOverlay: () => void;
-  /** Avslutar musiksession helt (t.ex. navigera tillbaka till repertoar). */
-  onExitSession: () => void;
   shellTitleId?: string;
   /** Spelläge: favoriter / bibliotek utan repertoar-sidebar */
   libraryQueueMaterials?: Material[] | null;
@@ -93,7 +90,6 @@ export function RepertoireMusicPlayerPanel({
   groupName,
   viewer,
   onMinimizeOverlay,
-  onExitSession,
   shellTitleId,
   libraryQueueMaterials = null,
   libraryPlaybackIntent = null,
@@ -102,7 +98,6 @@ export function RepertoireMusicPlayerPanel({
   initialPlaylistId = null,
   repertoirePlaybackIntent = null,
 }: RepertoireMusicPlayerPanelProps) {
-  const navigate = useNavigate();
   const { getAuthHeaders } = useAuth();
   const { pendingResume, clearPendingResume, clearInitialRepertoireLaunch } =
     useMusicPlayerOverlay();
@@ -215,13 +210,6 @@ export function RepertoireMusicPlayerPanel({
     );
     setPlaylistMenuCoords({ top: r.bottom + 4, left });
   }, []);
-
-  const repertoiresHref = useMemo(() => {
-    if (!groupName) return "/";
-    if (viewer === "leader") return `/leader/choir/${groupName}/repertoires`;
-    if (viewer === "admin") return `/admin/groups/${groupName}/repertoires`;
-    return `/user/me/${groupName}/repertoires`;
-  }, [groupName, viewer]);
 
   const audioMaterials = useMemo(
     () =>
@@ -415,11 +403,6 @@ export function RepertoireMusicPlayerPanel({
     setPlayerStartIndex(safeIndex);
     setHighlightedTrackIndex(safeIndex);
     setPlayerQueue(tracks);
-  };
-
-  const handleToRepertoires = () => {
-    navigate(repertoiresHref);
-    onExitSession();
   };
 
   const handlePlayFavorites = () => {
@@ -865,17 +848,9 @@ export function RepertoireMusicPlayerPanel({
         <div className={styles.shellTopRight}>
           <button
             type="button"
-            className={styles.backLink}
-            onClick={handleToRepertoires}
-          >
-            <ChevronLeft size={16} aria-hidden />
-            {isFavoritesView ? "Mitt bibliotek" : "Repertoar"}
-          </button>
-          <button
-            type="button"
             className={styles.closeButton}
             onClick={onMinimizeOverlay}
-            aria-label="Stäng musik"
+            aria-label="Minimera musikspelare"
           >
             <X size={20} aria-hidden />
           </button>


### PR DESCRIPTION
- Route admin/leader repertoire material playback through the global music overlay instead of a page-local MediaPlayer
- Remove the full-screen Repertoar back control and keep a single minimize action so playback continues in the mini player
- Clarify overlay minimize affordances in aria labels and highlight the active track on admin material pages