### PR TITLE
fix(material-api): remove unauthenticated group materials route

### DIFF
--- a/packages/material-api/functions/list.ts
+++ b/packages/material-api/functions/list.ts
@@ -15,16 +15,8 @@ export const handler = async (
   }
 
   try {
-    
-    let groupName = event.pathParameters?.groupName;
+    const groupName = event.requestContext.authorizer?.lambda?.group;
 
-    // Om inget kör finns i URL:en, fall tillbaka på att hämta det
-    // från den inloggade användarens token (för vanliga medlemmar)
-    if (!groupName) {
-      groupName = event.requestContext.authorizer?.lambda?.group;
-    }
-
-    // Om vi fortfarande inte har ett kör namn, kan vi inte fortsätta.
     if (!groupName) {
       return sendError(400, "Group could not be determined.");
     }

--- a/packages/material-api/yaml/material-functions.yml
+++ b/packages/material-api/yaml/material-functions.yml
@@ -93,13 +93,10 @@ createPracticeMaterial:
       Resource: ["arn:aws:cognito-idp:${self:provider.region}:${aws:accountId}:userpool/${self:custom.userPoolId}"]
 
 listMaterials:
-  handler: functions/list.handler # Båda endpoints använder samma handler
+  handler: functions/list.handler
   name: hrk-list-materials-${sls:stage}
-  description: Fetches materials for a group, either from URL param or auth context.
+  description: Fetches materials for the logged-in user's choir.
   events:
-    - httpApi:
-        method: GET
-        path: /groups/{groupName}/materials
     - httpApi:
         method: GET
         path: /my-materials


### PR DESCRIPTION
Closes audit Fas 1.1 — the public GET /groups/{groupName}/materials endpoint allowed listing choir material without login. Frontend uses authenticated repertoire and practice routes only; /my-materials remains.