### PR TITLE
feat(material): presigned S3 URLs for in-app media playback

### DIFF
--- a/packages/core/utils/permissions.ts
+++ b/packages/core/utils/permissions.ts
@@ -58,6 +58,7 @@ export const routePermissions: Record<string, RoleTypes[]> = {
   "POST /materials/batch-delete": RoleGroups.ADMIN_ONLY,
   "POST /materials/sync-all-repertoires": RoleGroups.ADMIN_ONLY,
   "GET /my-materials": RoleGroups.ALL_LOGGED_IN, // <-- KORRIGERAD
+  "POST /materials/download-urls": RoleGroups.ALL_LOGGED_IN,
   "POST /groups/{groupName}/repertoires": RoleGroups.MANAGEMENT,
   "GET /groups/{groupName}/repertoires": RoleGroups.ALL_LOGGED_IN,
   "DELETE /groups/{groupName}/repertoires/{repertoireId}":

--- a/packages/frontend/src/components/member/MemberWeekAccordion.tsx
+++ b/packages/frontend/src/components/member/MemberWeekAccordion.tsx
@@ -6,10 +6,8 @@ import styles from './MemberWeekAccordion.module.scss';
 import { FiChevronDown, FiChevronUp } from 'react-icons/fi';
 
 // MaterialCategory-komponenten från din PracticePage.tsx, nu flyttad hit
-import { FileText, Music, Video, Download, Eye } from 'lucide-react';
+import { FileText, Music, Video, Eye } from 'lucide-react';
 import { FaPlayCircle } from "react-icons/fa";
-
-const S3_PUBLIC_URL = import.meta.env.VITE_S3_BUCKET_URL;
 
 interface MaterialCategoryProps {
   title: string;
@@ -26,7 +24,7 @@ const MaterialCategory: React.FC<MaterialCategoryProps> = ({ title, files, onPla
     if (key.match(/\.(mp3|wav|m4a)$/)) return <Music size={20} className={styles.fileIcon} />;
     if (key.match(/\.(mp4|mov|webm)$/)) return <Video size={20} className={styles.fileIcon} />;
     if (key.match(/\.(pdf|txt)$/)) return <FileText size={20} className={styles.fileIcon} />;
-    return <Download size={20} className={styles.fileIcon} />;
+    return <FileText size={20} className={styles.fileIcon} />;
   };
 
   const isPlayableAudio = (fileKey: string = '') => fileKey.toLowerCase().match(/\.(mp3|wav|m4a)$/);
@@ -39,7 +37,6 @@ const MaterialCategory: React.FC<MaterialCategoryProps> = ({ title, files, onPla
         {files.map(material => {
           if (!material.fileKey) return null;
           const displayName = material.title || material.fileKey.split('/').pop() || 'Okänd titel';
-          const fullUrl = `${S3_PUBLIC_URL}/${material.fileKey}`;
 
           return (
             <div key={material.materialId} className={styles.materialItem}>
@@ -57,11 +54,6 @@ const MaterialCategory: React.FC<MaterialCategoryProps> = ({ title, files, onPla
                   <button onClick={() => onView(material)} className={`${styles.actionButton} ${styles.viewButton}`} aria-label={`Visa ${displayName}`}>
                     <Eye size={30} />
                   </button>
-                )}
-                 {!isPlayableAudio(material.fileKey) && !isViewable(material.fileKey) && (
-                  <a href={fullUrl} target="_blank" rel="noopener noreferrer" className={styles.actionButton} aria-label={`Ladda ner ${displayName}`}>
-                    <Download size={22} />
-                  </a>
                 )}
               </div>
             </div>

--- a/packages/frontend/src/components/ui/modal/MediaModal.tsx
+++ b/packages/frontend/src/components/ui/modal/MediaModal.tsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import type { Material } from '@/types/index';
 import styles from './MediaModal.module.scss';
 import { IoClose } from 'react-icons/io5';
+import { useMediaDownloadUrl } from '@/hooks/useMediaDownloadUrl';
 
 interface MediaModalProps {
   isOpen: boolean;
@@ -11,32 +12,31 @@ interface MediaModalProps {
   material: Material | null;
 }
 
-const FILE_BASE_URL = import.meta.env.VITE_S3_BUCKET_URL;
-
 export const MediaModal = ({ isOpen, onClose, material }: MediaModalProps) => {
   const [textContent, setTextContent] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
+  const [textLoading, setTextLoading] = useState(false);
+  const { url: mediaUrl, isLoading: urlLoading, error: urlError } = useMediaDownloadUrl(
+    isOpen && material?.fileKey ? material.fileKey : undefined
+  );
 
   useEffect(() => {
-    // Nollställ textinnehåll när materialet ändras
     setTextContent('');
 
-    if (material && material.fileKey.toLowerCase().endsWith('.txt')) {
+    if (material && mediaUrl && material.fileKey.toLowerCase().endsWith('.txt')) {
       const fetchTextContent = async () => {
-        setIsLoading(true);
-        const fullUrl = `${FILE_BASE_URL}/${material.fileKey}`;
+        setTextLoading(true);
         try {
-          const response = await axios.get(fullUrl);
+          const response = await axios.get(mediaUrl);
           setTextContent(response.data);
-        } catch (e) {
-          setTextContent("Kunde inte ladda textfilen.");
+        } catch {
+          setTextContent('Kunde inte ladda textfilen.');
         } finally {
-          setIsLoading(false);
+          setTextLoading(false);
         }
       };
-      fetchTextContent();
+      void fetchTextContent();
     }
-  }, [material]);
+  }, [material, mediaUrl]);
 
   useEffect(() => {
     const handleEsc = (event: KeyboardEvent) => {
@@ -49,18 +49,26 @@ export const MediaModal = ({ isOpen, onClose, material }: MediaModalProps) => {
   if (!isOpen || !material) return null;
 
   const displayName = material.title || material.fileKey.split('/').pop() || 'Okänd fil';
+  const normalizedFileKey = material.fileKey.toLowerCase();
 
   const renderContent = () => {
-    const fullUrl = `${FILE_BASE_URL}/${material.fileKey}`;
-    const normalizedFileKey = material.fileKey.toLowerCase();
+    if (urlLoading) {
+      return <p>Laddar media...</p>;
+    }
+    if (urlError || !mediaUrl) {
+      return <p>{urlError ?? 'Kunde inte ladda filen.'}</p>;
+    }
 
-    // NYTT: Logik för att rendera videofiler
-    if (normalizedFileKey.endsWith('.mp4') || normalizedFileKey.endsWith('.webm') || normalizedFileKey.endsWith('.mov')) {
+    if (
+      normalizedFileKey.endsWith('.mp4') ||
+      normalizedFileKey.endsWith('.webm') ||
+      normalizedFileKey.endsWith('.mov')
+    ) {
       return (
-        <video 
-          src={fullUrl} 
-          className={styles.videoPlayer} // Du behöver lägga till denna klass i din .scss-fil
-          controls 
+        <video
+          src={mediaUrl}
+          className={styles.videoPlayer}
+          controls
           autoPlay
           aria-label={`Videospelare för ${displayName}`}
         >
@@ -68,19 +76,25 @@ export const MediaModal = ({ isOpen, onClose, material }: MediaModalProps) => {
         </video>
       );
     }
-    
+
     if (normalizedFileKey.endsWith('.pdf')) {
-  // Använd Google Docs Viewer för bättre kompatibilitet på mobila enheter
-  const viewerUrl = `https://docs.google.com/gview?url=${encodeURIComponent(fullUrl)}&embedded=true`;
-  return <iframe src={viewerUrl} className={styles.pdfViewer} title={displayName} frameBorder="0" />;
-}
-    
+      const viewerUrl = `https://docs.google.com/gview?url=${encodeURIComponent(mediaUrl)}&embedded=true`;
+      return (
+        <iframe
+          src={viewerUrl}
+          className={styles.pdfViewer}
+          title={displayName}
+          frameBorder="0"
+        />
+      );
+    }
+
     if (normalizedFileKey.endsWith('.txt')) {
-      if (isLoading) return <p>Laddar text...</p>;
+      if (textLoading) return <p>Laddar text...</p>;
       return <pre className={styles.textContent}>{textContent}</pre>;
     }
-    
-    return <p>Filtypen kan inte förhandsvisas. <a href={fullUrl} target="_blank" rel="noopener noreferrer">Öppna i ny flik</a></p>;
+
+    return <p>Den här filtypen kan bara användas i appen och kan inte förhandsvisas här.</p>;
   };
 
   const mount =
@@ -98,9 +112,7 @@ export const MediaModal = ({ isOpen, onClose, material }: MediaModalProps) => {
             <IoClose size={24} />
           </button>
         </header>
-        <div className={styles.content}>
-          {renderContent()}
-        </div>
+        <div className={styles.content}>{renderContent()}</div>
       </div>
     </div>,
     mount

--- a/packages/frontend/src/hooks/useMediaDownloadUrl.ts
+++ b/packages/frontend/src/hooks/useMediaDownloadUrl.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/context/AuthContext';
+import { getMediaDownloadUrl } from '@/services/mediaUrlService';
+
+/**
+ * Resolves a presigned media URL for a single fileKey (cached in mediaUrlService).
+ */
+export function useMediaDownloadUrl(fileKey: string | undefined): {
+  url: string | null;
+  isLoading: boolean;
+  error: string | null;
+} {
+  const { getAuthHeaders } = useAuth();
+  const [url, setUrl] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const key = fileKey?.trim();
+    if (!key) {
+      setUrl(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    getMediaDownloadUrl(key, getAuthHeaders())
+      .then((resolved) => {
+        if (!cancelled) setUrl(resolved);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setUrl(null);
+          setError('Kunde inte ladda filen.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fileKey, getAuthHeaders]);
+
+  return { url, isLoading, error };
+}

--- a/packages/frontend/src/pages/member/RepertoireMusicPlayerPanel.tsx
+++ b/packages/frontend/src/pages/member/RepertoireMusicPlayerPanel.tsx
@@ -39,9 +39,12 @@ import { useAuth } from "@/context/AuthContext";
 import { saveRecentPlayback } from "@/utils/recentPlayback";
 import {
   formatDisplayTitle,
-  hashMediaSourcesKey,
   isPlayableAudioFile,
 } from "@/utils/media";
+import {
+  buildMediaPlayerTracks,
+  hashTrackQueueKey,
+} from "@/services/mediaUrlService";
 import { useFavorites } from "@/hooks/useFavorites";
 import { usePlaylists } from "@/hooks/usePlaylists";
 import {
@@ -56,7 +59,6 @@ import tracklistWatermarkLogo from "@/assets/images/hrk-logo.webp";
 import styles from "./RepertoireMusicPlayerPage.module.scss";
 
 const API_BASE_URL = import.meta.env.VITE_MATERIAL_API_URL;
-const FILE_BASE_URL = import.meta.env.VITE_S3_BUCKET_URL;
 
 const LIBRARY_SELECTED_ID = "__library__";
 
@@ -219,29 +221,20 @@ export function RepertoireMusicPlayerPanel({
   );
 
   const buildTracksFromMaterials = useCallback(
-    (items: Material[]): MediaPlayerTrack[] => {
-      return items
-        .filter((m) => m.fileKey && isPlayableAudioFile(m.fileKey))
-        .map((m) => ({
-          src: `${FILE_BASE_URL}/${m.fileKey}`,
-          title:
-            formatDisplayTitle(
-              m.title || m.fileKey?.split("/").pop() || "",
-            ) || "Okänd",
-          materialId: m.materialId,
-        }));
+    async (items: Material[]): Promise<MediaPlayerTrack[]> => {
+      return buildMediaPlayerTracks(items, getAuthHeaders());
     },
-    [],
+    [getAuthHeaders],
   );
 
   /** Byt key bara när köns identitet ändras — inte vid spårbyte (samma lista), så MediaPlayer kan följa initialTrackIndex utan remount. */
   const mediaPlayerMountKey = useMemo(() => {
     if (hasLibraryPlaybackQueue && playerQueue.length > 0) {
-      const sig = hashMediaSourcesKey(playerQueue.map((t) => t.src));
+      const sig = hashTrackQueueKey(playerQueue);
       return `lib-${groupName}-${sig}`;
     }
     if (!selectedId || playerQueue.length === 0) return "idle";
-    const sig = hashMediaSourcesKey(playerQueue.map((t) => t.src));
+    const sig = hashTrackQueueKey(playerQueue);
     return `${selectedId}-${sig}`;
   }, [hasLibraryPlaybackQueue, groupName, selectedId, playerQueue]);
 
@@ -364,27 +357,36 @@ export function RepertoireMusicPlayerPanel({
       setRepertoires([]);
     }
 
-    const tracks = buildTracksFromMaterials(libraryQueueMaterials);
     const intent: LibraryPlaybackIntent = libraryPlaybackIntent ?? "browse";
 
-    if (tracks.length === 0 || intent === "browse") {
-      setPlayerQueue([]);
-      return;
-    }
+    let cancelled = false;
 
-    if (intent === "playAll") {
-      setPlayerStartIndex(0);
-      setHighlightedTrackIndex(0);
-      setPlayerQueue(tracks);
-      return;
-    }
+    void buildTracksFromMaterials(libraryQueueMaterials).then((tracks) => {
+      if (cancelled) return;
 
-    if (intent.type === "fromIndex") {
-      const safe = Math.min(Math.max(0, intent.index), tracks.length - 1);
-      setPlayerStartIndex(safe);
-      setHighlightedTrackIndex(safe);
-      setPlayerQueue(tracks);
-    }
+      if (tracks.length === 0 || intent === "browse") {
+        setPlayerQueue([]);
+        return;
+      }
+
+      if (intent === "playAll") {
+        setPlayerStartIndex(0);
+        setHighlightedTrackIndex(0);
+        setPlayerQueue(tracks);
+        return;
+      }
+
+      if (intent.type === "fromIndex") {
+        const safe = Math.min(Math.max(0, intent.index), tracks.length - 1);
+        setPlayerStartIndex(safe);
+        setHighlightedTrackIndex(safe);
+        setPlayerQueue(tracks);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     libraryQueueMaterials,
     libraryPlaybackIntent,
@@ -394,14 +396,15 @@ export function RepertoireMusicPlayerPanel({
 
   const handlePlayTrackAt = (index: number) => {
     setActiveDropdownId(null);
-    const tracks = buildTracksFromMaterials(
+    void buildTracksFromMaterials(
       materials.filter((m) => m.fileKey && isPlayableAudioFile(m.fileKey)),
-    );
-    if (tracks.length === 0) return;
-    const safeIndex = Math.min(Math.max(0, index), tracks.length - 1);
-    setPlayerStartIndex(safeIndex);
-    setHighlightedTrackIndex(safeIndex);
-    setPlayerQueue(tracks);
+    ).then((tracks) => {
+      if (tracks.length === 0) return;
+      const safeIndex = Math.min(Math.max(0, index), tracks.length - 1);
+      setPlayerStartIndex(safeIndex);
+      setHighlightedTrackIndex(safeIndex);
+      setPlayerQueue(tracks);
+    });
   };
 
   const handlePlayFavorites = () => {

--- a/packages/frontend/src/services/mediaUrlService.ts
+++ b/packages/frontend/src/services/mediaUrlService.ts
@@ -1,0 +1,110 @@
+import axios from 'axios';
+import type { Material } from '@/types';
+import type { MediaPlayerTrack } from '@/components/media/MediaPlayer';
+import { formatDisplayTitle, isPlayableAudioFile } from '@/utils/media';
+
+const API_BASE_URL = import.meta.env.VITE_MATERIAL_API_URL as string;
+const BATCH_SIZE = 50;
+/** Cache slightly below presigned URL lifetime (1 h from API). */
+const CACHE_TTL_MS = 50 * 60 * 1000;
+
+type CacheEntry = { url: string; expiresAt: number };
+
+const urlCache = new Map<string, CacheEntry>();
+
+function cacheGet(fileKey: string): string | undefined {
+  const entry = urlCache.get(fileKey);
+  if (!entry || entry.expiresAt <= Date.now()) {
+    urlCache.delete(fileKey);
+    return undefined;
+  }
+  return entry.url;
+}
+
+function cacheSet(fileKey: string, url: string, expiresInSeconds: number): void {
+  const ttlMs = Math.min(CACHE_TTL_MS, Math.max(60_000, expiresInSeconds * 1000 - 60_000));
+  urlCache.set(fileKey, { url, expiresAt: Date.now() + ttlMs });
+}
+
+/**
+ * Resolves presigned media URLs for in-app playback (audio, video, PDF viewer).
+ * Not exposed as user-facing download links.
+ */
+export async function getMediaDownloadUrls(
+  fileKeys: string[],
+  authHeaders: Record<string, string>
+): Promise<Record<string, string>> {
+  const normalized = [...new Set(fileKeys.map((k) => k.trim()).filter(Boolean))];
+  if (normalized.length === 0) return {};
+
+  const result: Record<string, string> = {};
+  const toFetch: string[] = [];
+
+  for (const key of normalized) {
+    const cached = cacheGet(key);
+    if (cached) {
+      result[key] = cached;
+    } else {
+      toFetch.push(key);
+    }
+  }
+
+  for (let i = 0; i < toFetch.length; i += BATCH_SIZE) {
+    const chunk = toFetch.slice(i, i + BATCH_SIZE);
+    const response = await axios.post<{ urls: Record<string, string>; expiresIn: number }>(
+      `${API_BASE_URL}/materials/download-urls`,
+      { fileKeys: chunk },
+      { headers: { ...authHeaders } }
+    );
+    const { urls, expiresIn } = response.data;
+    for (const [fileKey, url] of Object.entries(urls ?? {})) {
+      cacheSet(fileKey, url, expiresIn ?? 3600);
+      result[fileKey] = url;
+    }
+  }
+
+  return result;
+}
+
+export async function getMediaDownloadUrl(
+  fileKey: string,
+  authHeaders: Record<string, string>
+): Promise<string> {
+  const key = fileKey.trim();
+  const urls = await getMediaDownloadUrls([key], authHeaders);
+  const url = urls[key];
+  if (!url) {
+    throw new Error('Could not resolve media URL.');
+  }
+  return url;
+}
+
+export async function buildMediaPlayerTracks(
+  materials: Material[],
+  authHeaders: Record<string, string>
+): Promise<MediaPlayerTrack[]> {
+  const playable = materials.filter((m) => m.fileKey && isPlayableAudioFile(m.fileKey));
+  if (playable.length === 0) return [];
+
+  const fileKeys = playable.map((m) => m.fileKey.trim());
+  const urls = await getMediaDownloadUrls(fileKeys, authHeaders);
+
+  return playable
+    .filter((m) => urls[m.fileKey.trim()])
+    .map((m) => ({
+      src: urls[m.fileKey.trim()],
+      title:
+        formatDisplayTitle(m.title || m.fileKey?.split('/').pop() || '') || 'Okänd',
+      materialId: m.materialId,
+    }));
+}
+
+/** Stable queue identity — use materialIds, not presigned src URLs. */
+export function hashTrackQueueKey(tracks: MediaPlayerTrack[]): string {
+  const sig = tracks.map((t) => t.materialId ?? t.src).join('\0');
+  let h = 0;
+  for (let i = 0; i < sig.length; i += 1) {
+    h = (Math.imul(31, h) + sig.charCodeAt(i)) | 0;
+  }
+  return `m${(h >>> 0).toString(36)}`;
+}

--- a/packages/frontend/src/utils/media.ts
+++ b/packages/frontend/src/utils/media.ts
@@ -53,18 +53,18 @@ export function hashMediaSourcesKey(sources: string[]): string {
 }
 
 /**
- * Derives S3 object key from a full media URL (matches how tracks use `VITE_S3_BUCKET_URL` + fileKey).
+ * Derives S3 object key from a media URL (public base URL or presigned GET URL).
  */
 export function extractFileKeyFromMediaUrl(src: string | undefined): string | undefined {
   const t = src?.trim();
   if (!t) return undefined;
   const base = (import.meta.env.VITE_S3_BUCKET_URL as string | undefined)?.replace(/\/$/, '') ?? '';
   if (base && t.startsWith(base)) {
-    const key = t.slice(base.length).replace(/^\//, '');
+    const key = t.slice(base.length).replace(/^\//, '').split('?')[0];
     return key || undefined;
   }
   try {
-    const path = new URL(t).pathname.replace(/^\//, '');
+    const path = new URL(t).pathname.replace(/^\//, '').split('?')[0];
     return path || undefined;
   } catch {
     return undefined;

--- a/packages/material-api/functions/getDownloadUrls.ts
+++ b/packages/material-api/functions/getDownloadUrls.ts
@@ -1,0 +1,72 @@
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { APIGatewayProxyEvent, APIGatewayProxyResultV2 } from "aws-lambda";
+import { sendResponse, sendError } from "../../core/utils/http";
+
+const s3Client = new S3Client({ region: process.env.AWS_REGION });
+const BUCKET_NAME = process.env.MEDIA_BUCKET_NAME;
+const MAX_KEYS = 50;
+const EXPIRES_IN_SECONDS = 3600;
+
+/** Allowed S3 prefixes for choir media (matches upload paths). */
+const ALLOWED_KEY = /^(materials|practice)\/[^/\\][^\\]*$/;
+
+function isValidFileKey(key: string): boolean {
+  if (!key || key.length > 1024) return false;
+  if (key.includes("..")) return false;
+  if (key.startsWith("/")) return false;
+  return ALLOWED_KEY.test(key);
+}
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResultV2> => {
+  if (!BUCKET_NAME) {
+    return sendError(500, "Server configuration error: media bucket not configured.");
+  }
+
+  try {
+    const body = event.body ? JSON.parse(event.body) : {};
+    const rawKeys = body.fileKeys;
+
+    if (!Array.isArray(rawKeys) || rawKeys.length === 0) {
+      return sendError(400, "fileKeys array is required.");
+    }
+    if (rawKeys.length > MAX_KEYS) {
+      return sendError(400, `At most ${MAX_KEYS} fileKeys allowed per request.`);
+    }
+
+    const fileKeys: string[] = [];
+    for (const raw of rawKeys) {
+      if (typeof raw !== "string") {
+        return sendError(400, "Each fileKey must be a string.");
+      }
+      const trimmed = raw.trim();
+      if (!isValidFileKey(trimmed)) {
+        return sendError(400, "Invalid or disallowed fileKey.");
+      }
+      fileKeys.push(trimmed);
+    }
+
+    const uniqueKeys = [...new Set(fileKeys)];
+    const urls: Record<string, string> = {};
+
+    await Promise.all(
+      uniqueKeys.map(async (fileKey) => {
+        const command = new GetObjectCommand({
+          Bucket: BUCKET_NAME,
+          Key: fileKey,
+        });
+        urls[fileKey] = await getSignedUrl(s3Client, command, {
+          expiresIn: EXPIRES_IN_SECONDS,
+        });
+      })
+    );
+
+    return sendResponse({ urls, expiresIn: EXPIRES_IN_SECONDS }, 200);
+  } catch (error: unknown) {
+    console.error("Error generating download URLs:", error);
+    const message = error instanceof Error ? error.message : "Internal server error";
+    return sendError(500, message);
+  }
+};

--- a/packages/material-api/yaml/material-functions.yml
+++ b/packages/material-api/yaml/material-functions.yml
@@ -111,6 +111,25 @@ listMaterials:
       Resource:
         - "arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:custom.mainTableName}"
 
+getDownloadUrls:
+  handler: functions/getDownloadUrls.handler
+  name: hrk-get-download-urls-${sls:stage}
+  description: Returns presigned S3 GET URLs for in-app media playback (materials and practice files).
+  events:
+    - httpApi:
+        method: POST
+        path: /materials/download-urls
+        authorizer:
+          name: centralJwtAuthorizer
+  environment:
+    MEDIA_BUCKET_NAME: ${self:custom.mediaBucketName}
+  iamRoleStatements:
+    - Effect: "Allow"
+      Action:
+        - "s3:GetObject"
+      Resource:
+        - "arn:aws:s3:::${self:custom.mediaBucketName}/*"
+
 listAllGlobalMaterials:
   handler: functions/listAllGlobalMaterials.handler
   name: hrk-list-all-global-materials-${sls:stage}


### PR DESCRIPTION
Replace direct public bucket URLs with authenticated presigned GET URLs so media can stay private after infra hardening. Playback, modal preview, and admin upload flows unchanged for users; explicit download links removed.