### PR TITLE
fix(infra): block public access on media S3 bucket

### DIFF
--- a/packages/infra-service/storage/s3.yml
+++ b/packages/infra-service/storage/s3.yml
@@ -3,6 +3,11 @@ Resources:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: hrk-media-${sls:stage}-${aws:accountId} # Använd ${sls:stage} direkt här
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: true
+          BlockPublicPolicy: true
+          IgnorePublicAcls: true
+          RestrictPublicBuckets: true
         CorsConfiguration:
           CorsRules:
             - AllowedHeaders:


### PR DESCRIPTION
Enable PublicAccessBlock on HrkMediaBucket after presigned URL playback is live. Closes anonymous GetObject on choir media; CORS kept for uploads.